### PR TITLE
Fix windows build failure

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -42,6 +42,7 @@ include::{projdir}/gradle/cpp.gradle[]
 <3> Native libraries are specified as a component of type `NativeLibrarySpec` and defined by a name - `greeter` in this case.
 <4> Native binaries are specified as a component of type `NativeBinarySpec` and defined by a name - `main` in this case.
 <5> The `main` binary uses the `greeter` {c++} library and is specified using `cpp.lib`
+<6> When using the VC++ compiler, the library methods should be declared with `__declspec(dllexport)` for shared library. This defines the macro `DLL_EXPORT` based on which the declaration is modified.
 
 Now run
 

--- a/gradle/cpp.gradle
+++ b/gradle/cpp.gradle
@@ -14,7 +14,7 @@ model { // <2>
     binaries {
         withType(SharedLibraryBinarySpec) {
             if (toolChain in VisualCpp) {
-                cCompiler.define "DLL_EXPORT" // <6>
+                cppCompiler.define "DLL_EXPORT" // <6>
             }
         }
     }

--- a/gradle/cpp.gradle
+++ b/gradle/cpp.gradle
@@ -10,5 +10,13 @@ model { // <2>
             }
         }
     }
+
+    binaries {
+        withType(SharedLibraryBinarySpec) {
+            if (toolChain in VisualCpp) {
+                cCompiler.define "DLL_EXPORT" // <6>
+            }
+        }
+    }
 }
 

--- a/src/greeter/headers/greeter.hpp
+++ b/src/greeter/headers/greeter.hpp
@@ -11,11 +11,11 @@
 #endif
 
 
-class Greeter {
+class DECLSPEC Greeter {
 public:
     Greeter(std::string name_) : name(name_) {};
     Greeter() : name("World") {};
-    void DECLSPEC greet();
+    void greet();
 private:
     std::string name;
 };

--- a/src/greeter/headers/greeter.hpp
+++ b/src/greeter/headers/greeter.hpp
@@ -4,11 +4,18 @@
 #include <iostream>
 #include <string>
 
+#if defined(DLL_EXPORT)
+#define DECLSPEC __declspec(dllexport)
+#else
+#define DECLSPEC
+#endif
+
+
 class Greeter {
 public:
     Greeter(std::string name_) : name(name_) {};
     Greeter() : name("World") {};
-    void greet();
+    void DECLSPEC greet();
 private:
     std::string name;
 };


### PR DESCRIPTION
On windows, the method/class declarations for a shared library should have __declspec(dllexport) as part of the declaration. This was missing earlier causing linking errors in the windows build.